### PR TITLE
Enable user code to override struct timeout_cb

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -88,11 +88,12 @@ typedef uint64_t timeout_t;
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifndef TIMEOUT_CB_OVERRIDE
 struct timeout_cb {
 	void (*fn)();
 	void *arg;
 }; /* struct timeout_cb */
-
+#endif
 
 /*
  * T I M E O U T  I N T E R F A C E S


### PR DESCRIPTION
I've found that frequently a void function and a pointer are either
more or less than we want to attach to each timeout object.  This
patch makes it so that the user can define TIMEOUT_CB_OVERRIDE to
indicate that they have included their own definition of struct
timeout_cb.
