### PR TITLE
Implement a function to iterate over all pending timeouts

### DIFF
--- a/timeout.c
+++ b/timeout.c
@@ -579,6 +579,24 @@ static struct timeout *timeouts_min(struct timeouts *T) {
 	} \
 } while (0)
 
+TIMEOUT_PUBLIC int timeouts_foreach(struct timeouts *T, int (*fp)(struct timeout *, void *), void *cb_arg)
+{
+	struct timeout *to = NULL;
+	int rv;
+	unsigned i, j;
+
+	for (i = 0; i < countof(T->wheel); i++) {
+		for (j = 0; j < countof(T->wheel[i]); j++) {
+			TAILQ_FOREACH(to, &T->wheel[i][j], tqe) {
+				rv = fp(to,cb_arg);
+				if (rv)
+					return rv;
+			}
+		}
+	}
+	return 0;
+} /* timeouts_foreach */
+
 TIMEOUT_PUBLIC bool timeouts_check(struct timeouts *T, FILE *fp) {
 	timeout_t timeout;
 	struct timeout *to;

--- a/timeout.h
+++ b/timeout.h
@@ -188,6 +188,10 @@ TIMEOUT_PUBLIC bool timeouts_expired(struct timeouts *);
 TIMEOUT_PUBLIC bool timeouts_check(struct timeouts *, FILE *);
 /* return true if invariants hold. describes failures to optional file handle. */
 
+TIMEOUT_PUBLIC int timeouts_foreach(struct timeouts *, int (*fn)(struct timeout *, void *), void *);
+/* Run fn(timeout,arg) on every pending or expired timeout in the wheel. If
+ * any iteration returns nonzero, return the nonzero value immediately and
+ * stop looping. */
 
 /*
  * B O N U S  W H E E L  I N T E R F A C E S


### PR DESCRIPTION
Libevent needed this, and I expect that others will too.
