### PR TITLE
Make the 'timeouts' field in struct timeout optional.

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -118,8 +118,10 @@ struct timeout {
 	timeout_t expires;
 	/* absolute expiration time */
 
+#ifndef TIMEOUT_DISABLE_RELATIVE_ACCESS
 	struct timeouts *timeouts;
 	/* timeouts collection if member of */
+#endif
 
 	struct timeout_list *pending;
 	/* timeout list if pending on wheel or expiry queue */
@@ -135,6 +137,7 @@ struct timeout {
 TIMEOUT_PUBLIC struct timeout *timeout_init(struct timeout *, int);
 /* initialize timeout structure (same as TIMEOUT_INITIALIZER) */
 
+#ifndef TIMEOUT_DISABLE_RELATIVE_ACCESS
 TIMEOUT_PUBLIC bool timeout_pending(struct timeout *);
 /* true if on timing wheel, false otherwise */
  
@@ -143,7 +146,7 @@ TIMEOUT_PUBLIC bool timeout_expired(struct timeout *);
 
 TIMEOUT_PUBLIC void timeout_del(struct timeout *);
 /* remove timeout from any timing wheel (okay if not member of any) */
-
+#endif
 
 /*
  * T I M I N G  W H E E L  I N T E R F A C E S


### PR DESCRIPTION
This field eats a pointer for every struct timeout, and it only
exists in order to enable a set of APIs that omit the 'struct
timeouts' object. For some applications, the convenience of these
APIs is not worth the memory overhead. This patch makes it so
that applications can disable those APIs, and save some memory, by
defining TIMEOUT_DISABLE_RELATIVE_ACCESS at compile time.
