### PR TITLE
Allow the user to disable interval support at compilation time

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -99,7 +99,9 @@ struct timeout_cb {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifndef TIMEOUT_DISABLE_INTERVALS
 #define TIMEOUT_INT 0x01 /* interval (repeating) timeout */
+#endif
 #define TIMEOUT_ABS 0x02 /* treat timeout values as absolute */
 
 #define TIMEOUT_INITIALIZER(flags) { (flags) }
@@ -112,8 +114,10 @@ struct timeout_cb {
 struct timeout {
 	int flags;
 
+#ifndef TIMEOUT_DISABLE_INTERVALS
 	timeout_t interval;
 	/* timeout interval if periodic */
+#endif
 
 	timeout_t expires;
 	/* absolute expiration time */


### PR DESCRIPTION
Some users only need plain timeouts.  They shouldn't have to pay the
overhead for a field they will never set.  With this patch, they can
define TIMEOUT_DISABLE_INTERVALS and turn off the feature at compile
time.
