### PR TITLE
Add a .gitignore file, including generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+*.gcda
+*.gcov
+*.gcno
+*~
+/test-timeout
+/bench
+/bench-heap.so
+/bench-llrb.so
+/bench-wheel.so
+/bench.so


### PR DESCRIPTION
It's nice to have a .gitignore file including the files that the makefile generates and that your editor generates.
