### PR TITLE
Correct and simplify timeouts_readd()

### DIFF
--- a/test-timeout.c
+++ b/test-timeout.c
@@ -224,6 +224,7 @@ struct intervals_cfg {
 	int n_timeouts;
 	timeout_t start_at;
 	timeout_t end_at;
+	timeout_t skip;
 };
 
 int
@@ -259,23 +260,35 @@ check_intervals(struct intervals_cfg *cfg)
 
 	while (now < cfg->end_at) {
 		timeout_t delay = timeouts_timeout(tos);
+		if (cfg->skip && delay < cfg->skip)
+			delay = cfg->skip;
 		timeouts_step(tos, delay);
-
 		now += delay;
 
 		while (NULL != (to = timeouts_get(tos))) {
 			i = to - &t[0];
 			assert(&t[i] == to);
 			fired[i]++;
+			if (0 != (to->expires - cfg->start_at) % cfg->timeouts[i])
+				FAIL();
+			if (to->expires <= now)
+				FAIL();
+			if (to->expires > now + cfg->timeouts[i])
+				FAIL();
 		}
 		if (!timeouts_check(tos, stderr))
 			FAIL();
 	}
 
-	timeout_t duration = cfg->end_at - cfg->start_at;
+	timeout_t duration = now - cfg->start_at;
 	for (i = 0; i < cfg->n_timeouts; ++i) {
-		if (fired[i] != duration / cfg->timeouts[i])
-			FAIL();
+		if (cfg->skip) {
+			if (fired[i] > duration / cfg->timeouts[i])
+				FAIL();
+		} else {
+			if (fired[i] != duration / cfg->timeouts[i])
+				FAIL();
+		}
 		if (!timeout_pending(&t[i]))
 			FAIL();
 	}
@@ -418,25 +431,36 @@ main(int argc, char **argv)
 		.n_timeouts = sizeof(primes)/sizeof(timeout_t),
 		.start_at = 50,
 		.end_at = 5322,
+		.skip = 0,
 	};
 	DO(check_intervals(&icfg1));
 
 	struct intervals_cfg icfg2 = {
-		.timeouts = primes,
+		.timeouts = factors_of_1337,
 		.n_timeouts = sizeof(factors_of_1337)/sizeof(timeout_t),
 		.start_at = 50,
 		.end_at = 50000,
+		.skip = 0,
 	};
 	DO(check_intervals(&icfg2));
 
 	struct intervals_cfg icfg3 = {
-		.timeouts = primes,
+		.timeouts = multiples_of_five,
 		.n_timeouts = sizeof(multiples_of_five)/sizeof(timeout_t),
 		.start_at = 49,
 		.end_at = 5333,
+		.skip = 0,
 	};
 	DO(check_intervals(&icfg3));
 
+	struct intervals_cfg icfg4 = {
+		.timeouts = primes,
+		.n_timeouts = sizeof(primes)/sizeof(timeout_t),
+		.start_at = 50,
+		.end_at = 5322,
+		.skip = 16,
+	};
+	DO(check_intervals(&icfg4));
 
         if (n_failed) {
           puts("\nFAIL");

--- a/timeout.c
+++ b/timeout.c
@@ -358,18 +358,13 @@ static void timeouts_readd(struct timeouts *T, struct timeout *to) {
 	to->expires += to->interval;
 
 	if (to->expires <= T->curtime) {
-		if (to->expires < T->curtime) {
-			timeout_t n = T->curtime - to->expires;
-			timeout_t q = n / to->interval;
-			timeout_t r = n % to->interval;
-
-			if (r)
-				to->expires += (to->interval * q) + (to->interval - r);
-			else
-				to->expires += (to->interval * q);
-		} else {
-			to->expires += to->interval;
-		}
+		/* If we've missed the next firing of this timeout, reschedule
+		 * it to occur at the next multiple of its interval after
+		 * the last time that it fired.
+		 */
+		timeout_t n = T->curtime - to->expires;
+		timeout_t r = n % to->interval;
+		to->expires = T->curtime + (to->interval - r);
 	}
 
 	timeouts_sched(T, to, to->expires);


### PR DESCRIPTION
William Ahern tells me that the intent here is that timeout_readd()
should always reschedule the timeout at the first time in the future
that is an even multiple of to->interval, as if we had called:

```
     do {
             to->expires += to->interval;
     } while (to->expires <= T->curtime);
```

But of course, that's not efficient.  The implementation strategy
used in this patch simplifies the calculation down to a single %
operation, plus a few additions and subtractions.

To verify the correctness of the formula used here, note first that
        0 <= r < to->interval, and so
        0 < to->interval - r <= to->interval.  Since
        expires' = curtime + (interval - r),
        curtime < expires' <= curtime + interval,
and so the new expiration time is no more than one interval after
curtime.

Note second that since
        r = (curtime - expires) % interval,
        expires' = curtime + (interval - r), we have
        (expires' - expires) % interval =
            (curtime + (interval - r) - expires) % interval =
            (curtime - r - expires) % interval =
            (curtime - (curtime-expires) % interval - expires) % interval =
            (curtime - curtime + expires - expires) % interval =
            0.
And so the new expiration time is an even multiple of interval from
the original expiration time.

Since we have both properties we wanted, this formula should be right.
