### PR TITLE
Use a faster safe bitwise rotate implementation.

### DIFF
--- a/timeout-bitops.c
+++ b/timeout-bitops.c
@@ -163,7 +163,21 @@ static inline int ctz32(uint32_t x)
  * bit width, though we don't actually require those.
  */
 
-#if 1
+#if defined(_MSC_VER) && !defined(TIMEOUT_DISABLE_MSVC_BITOPS)
+/* MSVC provides these declarations in stdlib.h and intrin.h */
+
+#define rotr8(v,c) _rotr8((v),(c)&7)
+#define rotl8(v,c) _rotl8((v),(c)&7)
+#define rotr16(v,c) _rotr16((v),(c)&15)
+#define rotl16(v,c) _rotl16((v),(c)&15)
+#define rotr32(v,c) _rotr32((v),(c)&31)
+#define rotl32(v,c) _rotl32((v),(c)&31)
+#define rotr64(v,c) _rotr64((v),(c)&63)
+#define rotl64(v,c) _rotl64((v),(c)&63)
+
+#define DECLARE_ROTATE_(bits, type)
+
+#elif 1
 /* Many modern compilers recognize the idiom here as equivalent to rotr/rotl,
  * and emit a single instruction.
  */

--- a/timeout.c
+++ b/timeout.c
@@ -153,6 +153,9 @@
 
 typedef uint64_t wheel_t;
 
+#define rotr(v,c) rotr64((v),(c))
+#define rotl(v,c) rotl64((v),(c))
+
 #elif WHEEL_BIT == 5
 
 #define WHEEL_C(n) UINT32_C(n)
@@ -160,6 +163,9 @@ typedef uint64_t wheel_t;
 #define WHEEL_PRIx PRIx32
 
 typedef uint32_t wheel_t;
+
+#define rotr(v,c) rotr32((v),(c))
+#define rotl(v,c) rotl32((v),(c))
 
 #elif WHEEL_BIT == 4
 
@@ -169,6 +175,9 @@ typedef uint32_t wheel_t;
 
 typedef uint16_t wheel_t;
 
+#define rotr(v,c) rotr16((v),(c))
+#define rotl(v,c) rotl16((v),(c))
+
 #elif WHEEL_BIT == 3
 
 #define WHEEL_C(n) UINT8_C(n)
@@ -177,25 +186,12 @@ typedef uint16_t wheel_t;
 
 typedef uint8_t wheel_t;
 
+#define rotr(v,c) rotr8((v),(c))
+#define rotl(v,c) rotl8((v),(c))
+
 #else
 #error invalid WHEEL_BIT value
 #endif
-
-
-static inline wheel_t rotl(const wheel_t v, int c) {
-	if (!(c &= (sizeof v * CHAR_BIT - 1)))
-		return v;
-
-	return (v << c) | (v >> (sizeof v * CHAR_BIT - c));
-} /* rotl() */
-
-
-static inline wheel_t rotr(const wheel_t v, int c) {
-	if (!(c &= (sizeof v * CHAR_BIT - 1)))
-		return v;
-
-	return (v >> c) | (v << (sizeof v * CHAR_BIT - c));
-} /* rotr() */
 
 
 /*


### PR DESCRIPTION
This branch replaces the rotation operation with one that compiles down to a single branchless rotate instruction (on my gcc and clang compilers).  The magic trick here is the fact that :

```
  (v >> (c&mask)) | (v << (-c&mask))
```

works even when c==0, is conformant c, doesn't require a branch, and many compilers can recognize it and replace it with a rotate instruction.

I have tested this, but I haven't benchmarked it yet or tested with super-old or super-weird compilers.  I would assume that eliminating these branch instructions is always a good idea, though, and it doesn't make the timeout.c code uglier.
