### PR TITLE
Optimization: Use LIST_ instead of TAILQ_.

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -121,7 +121,7 @@ struct timeout {
 	struct timeout_list *pending;
 	/* timeout list if pending on wheel or expiry queue */
 
-	TAILQ_ENTRY(timeout) tqe;
+	LIST_ENTRY(timeout) le;
 	/* entry member for struct timeout_list lists */
 
 #ifndef TIMEOUT_DISABLE_CALLBACKS


### PR DESCRIPTION
According to the queue(3) manpage, TAILQ "operations run about 20%
slower than lists". So using LIST_ instead ought to make our code much faster.

But this optimization comes at a nonzero cost to other aspects of the code.
Notably:

1) When multiple items are added expiring all at the same time, they
   will no longer be triggered in exactly the same order in which
   they were added. (Since we have to add to lists at the head,
   whereas we could add to tailqs at the tail.)

2) We need to use more stack space in timeouts_update, since we 
    can no longer concatenate many tailqs into one.

(Make sure to benchmark this before merging; it may not actually be
worthwhile. I have looked at the generated code, but not benchmarked it.
Also, I am not sure whether the issues I mention above make this patch a
bad idea or not.)
