### PR TITLE
Fix a signed overflow warning in test_timeouts.c

### DIFF
--- a/test-timeout.c
+++ b/test-timeout.c
@@ -433,7 +433,7 @@ main(int argc, char **argv)
 		.start_at = 100,
 		.end_at = ((uint64_t)1) << 49,
 		.n_timeouts = 1000,
-		.max_step = 1<<31,
+		.max_step = ((uint64_t)1) << 31,
 		.relative = 0,
 		.try_removing = 0,
 		.finalize = 2,


### PR DESCRIPTION
Technically, when int is 32-bit, 1<<31 is an overflow.
