### PR TITLE
check struct timeout_cb when defined TIMEOUT_CB_OVERRIDE

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -90,9 +90,11 @@ typedef uint64_t timeout_t;
 
 #ifndef TIMEOUT_CB_OVERRIDE
 struct timeout_cb {
-	void (*fn)();
+	void (*fn)(void);
 	void *arg;
 }; /* struct timeout_cb */
+#else
+#include "timeout_cb.h"
 #endif
 
 /*

--- a/timeout_cb.h
+++ b/timeout_cb.h
@@ -1,0 +1,5 @@
+/* Customize your own timeout callback here */
+struct timeout_cb {
+    void (*fn)(void);
+	void *arg;
+};


### PR DESCRIPTION
When make with TIMEOUT_CB_OVERRIDE macro:
```shell
make CPPFLAGS=-DTIMEOUT_CB_OVERRIDE
```
I get error "incomplete type 'struct timeout_cb'", so I write a check target for it.