### PR TITLE
add debug interface timeouts_pendings()

### DIFF
--- a/timeout.c
+++ b/timeout.c
@@ -622,6 +622,20 @@ TIMEOUT_PUBLIC bool timeouts_check(struct timeouts *T, FILE *fp) {
 	return 1;
 } /* timeouts_check() */
 
+#ifdef DEBUG
+TIMEOUT_PUBLIC int timeouts_pendings(struct timeouts *T, uint64_t **pendings) {
+    int i;
+    if (pendings) {
+        *pendings = (uint64_t *)malloc(sizeof(uint64_t) * WHEEL_NUM);
+        for (i = 0; i < WHEEL_NUM; i++) {
+            (*pendings)[i] = T->pending[i];
+        }
+        return WHEEL_NUM;
+    }
+    return 0;
+} /* timeouts_pendings() */
+#endif
+
 
 #define ENTER                                                           \
 	do {                                                            \

--- a/timeout.h
+++ b/timeout.h
@@ -198,6 +198,12 @@ TIMEOUT_PUBLIC bool timeouts_expired(struct timeouts *);
 TIMEOUT_PUBLIC bool timeouts_check(struct timeouts *, FILE *);
 /* return true if invariants hold. describes failures to optional file handle. */
 
+#ifdef DEBUG
+TIMEOUT_PUBLIC int timeouts_pendings(struct timeouts *, uint64_t **);
+/* return timing wheel number. copy pendings of all wheels to malloced memory
+ * (which need free by yourself). */
+#endif
+
 #define TIMEOUTS_PENDING 0x10
 #define TIMEOUTS_EXPIRED 0x20
 #define TIMEOUTS_ALL     (TIMEOUTS_PENDING|TIMEOUTS_EXPIRED)


### PR DESCRIPTION
Sometimes I want to check the value of pending field of struct timeouts for debug, then I implement this function.In my other c file, I can use it as this:
```c
void logPendings(struct timeouts *T)
{
    int i;
    uint64_t *pendings;
    int wheel = timeouts_pendings(T, &pendings);
    for (i = 0; i < wheel; ++i) {
        printf("%016llx \n", pendings[i]);
    }
    printf("\n");
    free(pendings);
}
```