### PR TITLE
fix cb macro

### DIFF
--- a/timeout.h
+++ b/timeout.h
@@ -107,9 +107,9 @@ struct timeout_cb {
 
 #define TIMEOUT_INITIALIZER(flags) { (flags) }
 
-#define timeout_setcb(to, fn, arg) do { \
-	(to)->callback.fn = (fn);       \
-	(to)->callback.arg = (arg);     \
+#define timeout_setcb(to, f, a) do { \
+	(to)->callback.fn = (f);       \
+	(to)->callback.arg = (a);     \
 } while (0)
 
 struct timeout {


### PR DESCRIPTION
The callback macro gets confused by the argument naming.